### PR TITLE
Extract code snippets from drafts

### DIFF
--- a/extractors/draft_extractor.py
+++ b/extractors/draft_extractor.py
@@ -50,6 +50,7 @@ class DraftExtractor:
         self.draft_path_only_example = draft_extractor_paths.get('draft_path_only_example', '')
         self.all_yang_path = draft_extractor_paths.get('all_yang_path', '')
         self.draft_path_no_strict = draft_extractor_paths.get('draft_path_no_strict', '')
+        self.code_snippets_directory = draft_extractor_paths.get('code_snippets_dir', '')
         self.debug_level = debug_level
         self.extract_examples = extract_examples
         self.extract_elements = extract_elements
@@ -175,7 +176,6 @@ class DraftExtractor:
         strict: bool = False,
         strict_examples: bool = False,
     ):
-        extracted = []
         old_stderr = None
         try:
             old_stderr = sys.stderr
@@ -191,6 +191,8 @@ class DraftExtractor:
                 add_line_refs=False,
                 force_revision_pyang=False,
                 force_revision_regexp=True,
+                extract_code_snippets=True,
+                code_snippets_dir=os.path.join(self.code_snippets_directory, os.path.splitext(draft_file)[0]),
             )
             result_string = result.getvalue()
         finally:

--- a/extractors/helper.py
+++ b/extractors/helper.py
@@ -37,7 +37,7 @@ def invert_yang_modules_dict(in_dict: dict, debug_level: int = 0):
     :return: inverted output dictionary
     """
     if debug_level > 0:
-        print('DEBUG: invert_yang_modules_dict: dictionary before inversion:\n{}'.format(str(in_dict)))
+        print(f'DEBUG: invert_yang_modules_dict: dictionary before inversion:\n{in_dict}')
 
     inv_dict = {}
     for key, yang_modules in in_dict.items():
@@ -45,7 +45,7 @@ def invert_yang_modules_dict(in_dict: dict, debug_level: int = 0):
             inv_dict[yang_model] = key
 
     if debug_level > 0:
-        print('DEBUG: invert_yang_modules_dict: dictionary after inversion:\n{}'.format(str(inv_dict)))
+        print(f'DEBUG: invert_yang_modules_dict: dictionary after inversion:\n{inv_dict}')
 
     return inv_dict
 
@@ -59,29 +59,29 @@ def remove_invalid_files(directory: str, yang_dict: dict):
         :param directory    (str) the directory to analyze for invalid filenames of extracted modules
         :param yang_dict    (dict) dictionary of key:extracted YANG modul name, value:RFC/Draft file name
     """
-    path = '{}*.yang'.format(directory)
+    path = f'{directory}*.yang'
     for full_path in glob.glob(path):
         filename = os.path.basename(full_path)
         if ' ' in filename:
             os.remove(full_path)
             if yang_dict.get(filename):
                 yang_dict.pop(filename)
-            print('Invalid YANG module removed: {}'.format(full_path))
+            print(f'Invalid YANG module removed: {full_path}')
         if '@YYYY-MM-DD' in filename:
             os.remove(full_path)
             if yang_dict.get(filename):
                 yang_dict.pop(filename)
-            print('Invalid YANG module removed: {}'.format(full_path))
+            print(f'Invalid YANG module removed: {full_path}')
         if filename.startswith('.yang'):
             os.remove(full_path)
             if yang_dict.get(filename):
                 yang_dict.pop(filename)
-            print('Invalid YANG module removed: {}'.format(full_path))
+            print(f'Invalid YANG module removed: {full_path}')
         if filename.startswith('@'):
             os.remove(full_path)
             if yang_dict.get(filename):
                 yang_dict.pop(filename)
-            print('Invalid YANG module removed: {}'.format(full_path))
+            print(f'Invalid YANG module removed: {full_path}')
 
 
 def check_after_xym_extraction(filename: str, extracted_yang_models: list):
@@ -94,13 +94,13 @@ def check_after_xym_extraction(filename: str, extracted_yang_models: list):
     """
     correct = True
     if any(' ' in extracted_model for extracted_model in extracted_yang_models):
-        print('File {} contains module with invalid name [{}]'.format(filename, ', '.join(extracted_yang_models)))
+        print(f'File {filename} contains module with invalid name [{", ".join(extracted_yang_models)}]')
         correct = False
     if any('YYYY-MM-DD' in extracted_model for extracted_model in extracted_yang_models):
-        print('File {} contains module with invalid revision [{}]'.format(filename, ', '.join(extracted_yang_models)))
+        print(f'File {filename} contains module with invalid revision [{", ".join(extracted_yang_models)}]')
         correct = False
     if any('.yang' == extracted_model for extracted_model in extracted_yang_models):
-        print('File {} contains module with missing name [{}]'.format(filename, ', '.join(extracted_yang_models)))
+        print(f'File {filename} contains module with missing name [{", ".join(extracted_yang_models)}]')
         correct = False
 
     return correct

--- a/extractors/rfc_extractor.py
+++ b/extractors/rfc_extractor.py
@@ -59,12 +59,12 @@ class RFCExtractor:
                     continue
 
                 if self.debug_level > 0:
-                    print('DEBUG: Extracted YANG models from RFC\n {}'.format(str(extracted_yang_models)))
+                    print(f'DEBUG: Extracted YANG models from RFC\n {extracted_yang_models}')
 
                 # typedef, grouping and identity extraction from RFCs
                 for extracted_model in extracted_yang_models:
                     if not extracted_model.startswith('example-'):
-                        print('Identifier definition extraction for {}'.format(extracted_model))
+                        print(f'Identifier definition extraction for {extracted_model}')
                         module_fname = os.path.join(self.rfc_yang_path, extracted_model)
                         extract_elem(module_fname, self.rfc_extraction_yang_path, 'typedef')
                         extract_elem(module_fname, self.rfc_extraction_yang_path, 'grouping')
@@ -101,7 +101,7 @@ class RFCExtractor:
             :param srcdir       (str) Source dir path from where we move the YANG modules
             :param dstdir       (str) Destinationd dir path to where we move the YANG modules
         """
-        with open('{}/../resources/old-rfcs.json'.format(os.path.dirname(os.path.realpath(__file__))), 'r') as f:
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../resources/old-rfcs.json'), 'r') as f:
             old_modules = json.load(f)
 
         for old_module in old_modules:

--- a/extractors/rfc_extractor.py
+++ b/extractors/rfc_extractor.py
@@ -28,11 +28,19 @@ from extractors.helper import check_after_xym_extraction, invert_yang_modules_di
 
 
 class RFCExtractor:
-    def __init__(self, rfc_path: str, rfc_yang_path: str, rfc_extraction_yang_path: str, debug_level: int):
+    def __init__(
+        self,
+        rfc_path: str,
+        rfc_yang_path: str,
+        rfc_extraction_yang_path: str,
+        code_snippets_directory: str,
+        debug_level: int,
+    ):
         self.rfc_path = rfc_path
         self.rfc_yang_path = rfc_yang_path
         self.rfc_extraction_yang_path = rfc_extraction_yang_path
         self.debug_level = debug_level
+        self.code_snippets_directory = code_snippets_directory
         self.ietf_rfcs = []
         self.rfc_yang_dict = {}
         self.inverted_rfc_yang_dict = {}
@@ -82,6 +90,8 @@ class RFCExtractor:
             add_line_refs=False,
             force_revision_pyang=False,
             force_revision_regexp=True,
+            extract_code_snippets=True,
+            code_snippets_dir=os.path.join(self.code_snippets_directory, os.path.splitext(rfc_file)[0]),
         )
 
     def invert_dict(self):


### PR DESCRIPTION
Added code snippets extraction during ietf modules extraction (will work when xym is updated)

**NOTE**: to test locally attach to module-compilation container, add the following lines at the top of the ```ietf_modules_extraction/extract_ietf_modules.py``` (this is needed becaue PYTHONPATH isn't set when scripts are run not from sh scripts):
```
import sys
sys.path.append('/module-compilation')
```
then run the following commands:
```
pip uninstall xym
pip install git+https://git@github.com/Fagtoy/xym.git@add_code_snippets_extraction#egg=xym
```
and then run the script
after the script execution you can see extracted code snippets by running:
```
docker cp yc-module-compilation:/usr/share/nginx/html/downloadables/code-snippets YOUR/PATH/TO/DIR
```

resolves #3 