### PR TITLE
Override compilation results in redis on populate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN echo "export PATH=$VIRTUAL_ENV:$PATH" >/etc/environment
 ENV GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git
 
 ENV VIRTUAL_ENV=/module-compilation
+ENV PYTHONPATH=$VIRTUAL_ENV
 ENV CONF=$VIRTUAL_ENV/conf
 ENV YANGVAR="get_config.py --section Directory-Section --key var"
 ENV BACKUPDIR="get_config.py --section Directory-Section --key backup"

--- a/metadata_generators/base_metadata_generator.py
+++ b/metadata_generators/base_metadata_generator.py
@@ -6,6 +6,7 @@ class BaseMetadataGenerator:
     def __init__(self, compilation_results: dict, compilation_status: str, yang_file: str, document_dict: dict):
         self.compilation_results = compilation_results
         self.compilation_status = compilation_status
+        self.yang_file_path = yang_file
         self.yang_file_name = os.path.basename(yang_file)
         self.document_dict = document_dict
 
@@ -13,11 +14,13 @@ class BaseMetadataGenerator:
         return {'compilation-status': self.compilation_status}
 
     class FileCompilationData(t.TypedDict):
+        yang_file_path: str
         compilation_metadata: tuple[str, ...]
         compilation_results: dict[str, str]
 
     def get_file_compilation(self) -> FileCompilationData:
         return self.FileCompilationData(
+            yang_file_path=self.yang_file_path,
             compilation_metadata=(self.compilation_status,),
             compilation_results=self.compilation_results.copy(),
         )

--- a/metadata_generators/draft_metadata_generator.py
+++ b/metadata_generators/draft_metadata_generator.py
@@ -41,6 +41,7 @@ class DraftMetadataGenerator(BaseMetadataGenerator):
         yang_model_url = '{}/YANG-modules/{}'.format(self.web_url, self.yang_file_name)
         yang_model_anchor = '<a href="{}">Download the YANG model</a>'.format(yang_model_url)
         return self.FileCompilationData(
+            yang_file_path=self.yang_file_path,
             compilation_metadata=(
                 self.draft_url_anchor,
                 self.email_anchor,

--- a/metadata_generators/example_metadata_generator.py
+++ b/metadata_generators/example_metadata_generator.py
@@ -7,6 +7,7 @@ class ExampleMetadataGenerator(DraftMetadataGenerator):
 
     def get_file_compilation(self) -> DraftMetadataGenerator.FileCompilationData:
         return self.FileCompilationData(
+            yang_file_path=self.yang_file_path,
             compilation_metadata=(
                 self.draft_url_anchor,
                 self.email_anchor,

--- a/modules_compilation/compile_modules.py
+++ b/modules_compilation/compile_modules.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # Copyright The IETF Trust 2019, All Rights Reserved
 # Copyright (c) 2018 Cisco and/or its affiliates.
 # This software is licensed to you under the terms of the Apache License, Version 2.0 (the "License").
@@ -12,6 +11,7 @@
 # License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied.
 
+import abc
 import argparse
 import datetime
 import json
@@ -19,6 +19,7 @@ import os
 import re
 import typing as t
 from configparser import ConfigParser
+from dataclasses import dataclass
 
 import requests
 from compilation_status import combined_compilation, pyang_compilation_status
@@ -52,318 +53,523 @@ __license__ = 'Apache License, Version 2.0'
 __email__ = 'bclaise@cisco.com'
 
 
-def get_mod_rev(yang_file) -> str:
-    name = ''
-    revision = ''
+class CompileModulesABC(abc.ABC):
+    ietf: t.Optional[IETF]
+    metadata_generator_cls: t.Type[BaseMetadataGenerator]
+    prefix: str
+    root_dir: str
+    documents_dict: dict
+    aggregated_results: dict
 
-    with open(yang_file, 'r', encoding='utf-8', errors='ignore') as module:
-        for line in module:
-            if name and revision:
-                return f'{name}@{revision}'
+    @dataclass
+    class Options:
+        debug_level: int
+        force_compilation: bool
+        lint: bool
+        allinclusive: bool
+        metadata: str
+        config: ConfigParser = create_config()
 
-            if name == '':
-                match = re.search(r'^\s*(sub)?module\s+([\w\-\d]+)', line)
-                if match:
-                    name = match.group(2).strip()
-                    continue
+    def __init__(self, options: Options):
+        self.config = options.config
+        self.yangcatalog_api_prefix = self.config.get('Web-Section', 'yangcatalog-api-prefix')
+        self.web_private = self.config.get('Web-Section', 'private-directory') + '/'
+        self.cache_directory = self.config.get('Directory-Section', 'cache')
+        self.modules_directory = self.config.get('Directory-Section', 'modules-directory')
+        self.temp_dir = self.config.get('Directory-Section', 'temp')
+        self.ietf_directory = self.config.get('Directory-Section', 'ietf-directory')
+        self.cached_compilation_results_path = os.path.join(self.web_private, f'{self.prefix}.json')
 
-            if not revision:
-                match = re.search(r'^\s*revision\s+"?([\d\-]+)"?', line)
-                if match:
-                    revision = match.group(1).strip()
-                    continue
-
-    return f'{name}@{revision}' if revision else name
-
-
-def custom_print(message: str):
-    timestamp = f'{datetime.datetime.now().time()} ({os.getpid()}):'
-    print(f'{timestamp} {message}', flush=True)
-
-
-def get_name_with_revision(yang_file: str) -> str:
-    yang_file_base = os.path.basename(yang_file)
-    out = get_mod_rev(yang_file)
-
-    if out.rstrip():
-        # Add the @revision to the yang_file if not present
-        if '@' in yang_file and '.yang' in yang_file:
-            new_yang_file_base_with_revision = f'{out.rstrip()}.yang'
-            if new_yang_file_base_with_revision.split('@')[0] != yang_file_base.split('@')[0]:
-                print(
-                    f'Name of the YANG file {yang_file_base} is wrong changing to correct one into '
-                    f'{new_yang_file_base_with_revision}',
-                    flush=True,
-                )
-                yang_file_base = new_yang_file_base_with_revision
-            if (
-                new_yang_file_base_with_revision.split('@')[1].split('.')[0]
-                != yang_file_base.split('@')[1].split('.')[0]
-            ):
-                print(
-                    f'Revision of the YANG file {yang_file_base} is wrong changing to correct as '
-                    f'{new_yang_file_base_with_revision}',
-                    flush=True,
-                )
-                yang_file_base = new_yang_file_base_with_revision
-
-            return yang_file_base
-        else:
-            new_yang_file_base_with_revision = f'{out.rstrip()}.yang'
-            if debug_level > 0:
-                print(
-                    f'DEBUG: Adding the revision to YANG module because xym can\'t get revision '
-                    f'(missing from the YANG module): {yang_file}',
-                )
-                print(f'DEBUG:  out: {new_yang_file_base_with_revision}')
-
-            return new_yang_file_base_with_revision
-    print(f'Unable to get name@revision out of {yang_file} - no output', flush=True)
-    return ''
-
-
-def get_modules(temp_dir: str, prefix: str) -> dict:
-    try:
-        with open(os.path.join(temp_dir, 'all_modules_data.json'), 'r') as f:
-            modules = json.load(f)
-            custom_print('All the modules data loaded from JSON files')
-    except (FileNotFoundError, json.decoder.JSONDecodeError):
-        modules = {}
-    if modules == {}:
-        modules = requests.get(f'{prefix}/search/modules').json()
-        custom_print('All the modules data loaded from API')
-    return modules
-
-
-def parse_module(
-    parsers: dict,
-    yang_file: str,
-    root_directory: str,
-    lint: bool,
-    allinclusive: bool,
-    previous_compilation_results: t.Optional[dict] = None,
-) -> tuple[str, dict]:
-    module_compilation_results = previous_compilation_results or {}
-    pyang_parser = parsers.get('pyang')
-    if pyang_parser:
-        module_compilation_results['pyang_lint'] = pyang_parser.run_pyang(
-            root_directory,
-            yang_file,
-            lint,
-            allinclusive,
-            True,
-        )
-        module_compilation_results['pyang'] = pyang_parser.run_pyang(
-            root_directory,
-            yang_file,
-            lint,
-            allinclusive,
-            False,
-        )
-    confd_parser = parsers.get('confdc')
-    if confd_parser:
-        module_compilation_results['confdrc'] = confd_parser.run_confdc(yang_file, root_directory, allinclusive)
-    yuma_parser = parsers.get('yangdumppro')
-    if yuma_parser:
-        module_compilation_results['yumadump'] = yuma_parser.run_yumadumppro(yang_file, root_directory, allinclusive)
-    yanglint_parser = parsers.get('yanglint')
-    if yanglint_parser:
-        module_compilation_results['yanglint'] = yanglint_parser.run_yanglint(yang_file, root_directory, allinclusive)
-    compilation_status = combined_compilation(os.path.basename(yang_file), module_compilation_results)
-    return compilation_status, module_compilation_results
-
-
-def parse_example_module(
-    parsers: dict,
-    yang_file: str,
-    root_directory: str,
-    lint: bool,
-    allinclusive: bool,
-    previous_compilation_results: t.Optional[dict] = None,
-):
-    module_compilation_results = previous_compilation_results or {}
-    pyang_parser = parsers.get('pyang')
-    if pyang_parser:
-        module_compilation_results['pyang_lint'] = pyang_parser.run_pyang(
-            root_directory,
-            yang_file,
-            lint,
-            allinclusive,
-            True,
-        )
-        module_compilation_results['pyang'] = pyang_parser.run_pyang(
-            root_directory,
-            yang_file,
-            lint,
-            allinclusive,
-            False,
-        )
-    compilation_status = pyang_compilation_status(module_compilation_results['pyang_lint'])
-    return compilation_status, module_compilation_results
-
-
-def validate(
-    prefix: str,
-    modules: dict,
-    yang_list: list,
-    parser_args: dict,
-    document_dict: dict,
-    config: ConfigParser,
-) -> dict:
-    agregate_results = {'all': {}, 'no_submodules': {}}
-    parsers = {
-        'pyang': PyangParser(debug_level, config=config),
-        'confdc': ConfdcParser(debug_level),
-        'yangdumppro': YangdumpProParser(debug_level),
-        'yanglint': YanglintParser(debug_level),
-    }
-    all_yang_catalog_metadata = {}
-    for module in modules['module']:
-        try:
-            key = f'{module["name"]}@{module["revision"]}'
-        except KeyError:
-            continue
-        all_yang_catalog_metadata[key] = module
-
-    cached_compilation_results_filename = 'IETFCiscoAuthors.json' if ietf == IETF.DRAFT else f'{prefix}.json'
-    cached_compilation_results_path = os.path.join(web_private, cached_compilation_results_filename)
-    try:
-        with open(cached_compilation_results_path, 'r') as f:
-            cached_compilation_results = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        cached_compilation_results = {}
-
-    validator_versions_to_check = {
-        'pyang': validator_versions['pyang_version'],
-        'confdc': validator_versions['confd_version'],
-        'yangdumppro': validator_versions['yangdump_version'],
-        'yanglint': validator_versions['yanglint_version'],
-    }
-    for yang_file_path in yang_list:
-        yang_file_with_revision = get_name_with_revision(yang_file_path)
-        if not yang_file_with_revision:
-            continue
-        yang_file_compilation_data = cached_compilation_results.get(yang_file_with_revision)
-        previous_compilation_results = (
-            yang_file_compilation_data.get('compilation_results')
-            if yang_file_compilation_data and isinstance(yang_file_compilation_data, dict)
-            else None
-        )
-        module_hash_info = file_hasher.should_parse(yang_file_path)
-        changed_validator_versions = module_hash_info.get_changed_validator_versions(validator_versions_to_check)
-        if not previous_compilation_results or module_hash_info.hash_changed or changed_validator_versions:
-            parsers_to_use, module_compilation_results = _get_module_parsers_to_use_and_previous_compilation_results(
-                parsers,
-                previous_compilation_results,
-                module_hash_info,
-                changed_validator_versions,
-            )
-            compilation_status, module_compilation_results = _parse_module(
-                yang_file_path,
-                parsers_to_use,
-                parser_args,
-                module_compilation_results,
-            )
-
-            metadata_generator = metadata_generator_cls(
-                module_compilation_results,
-                compilation_status,
-                yang_file_path,
-                document_dict,
-            )
-            confd_metadata = metadata_generator.get_confd_metadata()
-            yang_file_compilation_data = metadata_generator.get_file_compilation()
-
-            check_yangcatalog_data(
-                config,
-                yang_file_path,
-                confd_metadata,
-                module_compilation_results,
-                all_yang_catalog_metadata,
-                ietf,
-            )
-
-            # Revert to previous hash if compilation status is 'UNKNOWN' -> try to parse model again next time
-            if compilation_status != 'UNKNOWN':
-                file_hasher.updated_hashes[yang_file_path] = {
-                    'hash': module_hash_info.hash,
-                    'validator_versions': validator_versions_to_check,
-                }
-
-        agregate_results['all'][yang_file_with_revision] = yang_file_compilation_data
-        if module_or_submodule(yang_file_path) == 'module':
-            agregate_results['no_submodules'][yang_file_with_revision] = yang_file_compilation_data
-    return agregate_results
-
-
-def _get_module_parsers_to_use_and_previous_compilation_results(
-    all_parsers: dict,
-    previous_compilation_results: dict,
-    module_hash_info: FileHasher.ModuleHashCheckForParsing,
-    changed_validator_versions: list[str],
-) -> tuple[dict, dict]:
-    if previous_compilation_results and not module_hash_info.hash_changed and changed_validator_versions:
-        parsers_to_use = {
-            parser_name: parser_object
-            for parser_name, parser_object in all_parsers.items()
-            if parser_name in changed_validator_versions
+        self.debug_level = options.debug_level
+        self.lint = options.lint
+        self.allinclusive = options.allinclusive
+        self.metadata = options.metadata
+        self.file_hasher = FileHasher(force_compilation=options.force_compilation, config=self.config)
+        self.files_generator = FilesGenerator(self.web_private)
+        self.parsers = {
+            'pyang': PyangParser(self.debug_level, config=self.config),
+            'confdc': ConfdcParser(self.debug_level),
+            'yangdumppro': YangdumpProParser(self.debug_level),
+            'yanglint': YanglintParser(self.debug_level),
         }
-        return parsers_to_use, previous_compilation_results
-    return all_parsers, {}
+        self.validator_versions = {
+            'pyang': validator_versions['pyang_version'],
+            'confdc': validator_versions['confd_version'],
+            'yangdumppro': validator_versions['yangdump_version'],
+            'yanglint': validator_versions['yanglint_version'],
+        }
 
-
-def _parse_module(
-    yang_file_path: str,
-    parsers_to_use: dict,
-    parser_args: dict,
-    previous_compilation_results: dict,
-) -> tuple[str, dict]:
-    if ietf == IETF.EXAMPLE:
-        return parse_example_module(
-            parsers_to_use, yang_file_path, **parser_args, previous_compilation_results=previous_compilation_results
+    def __call__(self):
+        self._custom_print(f'Start of job in {self.root_dir}')
+        self.parser_args = {'root_directory': self.root_dir, 'lint': self.lint, 'allinclusive': self.allinclusive}
+        self.yang_list = list_files_by_extensions(
+            self.root_dir,
+            ('yang',),
+            return_full_paths=True,
+            recursive=True,
+            debug_level=self.debug_level,
         )
-    return parse_module(
-        parsers_to_use, yang_file_path, **parser_args, previous_compilation_results=previous_compilation_results
-    )
+        if self.debug_level > 0:
+            print(f'yang_list content:\n{self.yang_list}')
+        self._custom_print(f'relevant files list built, {len(self.yang_list)} modules found in {self.root_dir}')
+        self.modules = self._get_modules()
+        self.aggregated_results = self._compile_modules()
+        self._custom_print('all modules compiled/validated')
+        self._generate_compilation_files()
+        compilation_stats = self._generate_statistics_page()
+        self._print_compilation_results_summary(compilation_stats)
+        self.file_hasher.dump_hashed_files_list()
+        self._custom_print(f'end of {os.path.basename(__file__)} job for {self.prefix}')
 
+    def _custom_print(self, message: str):
+        timestamp = f'{datetime.datetime.now().time()} ({os.getpid()}):'
+        print(f'{timestamp} {message}', flush=True)
 
-def write_page_main(prefix: str, compilation_stats: dict) -> dict:  # pyright: ignore
-    stats_directory = os.path.join(web_private, 'stats')
-    os.makedirs(stats_directory, exist_ok=True)
-    with FileLock(os.path.join(stats_directory, 'stats.json.lock')):
-        stats_file_path = os.path.join(stats_directory, 'AllYANGPageMain.json')
-        counter = 5
-        while True:
+    def _get_modules(self) -> dict:
+        try:
+            with open(os.path.join(self.temp_dir, 'all_modules_data.json'), 'r') as f:
+                modules_data = json.load(f)
+                self._custom_print('All the modules data loaded from JSON files')
+        except (FileNotFoundError, json.decoder.JSONDecodeError):
+            modules_data = None
+        if not modules_data:
+            modules_data = requests.get(f'{self.yangcatalog_api_prefix}/search/modules').json()
+            self._custom_print('All the modules data loaded from API')
+        modules = {}
+        for module in modules_data['module']:
             try:
-                if not os.path.exists(stats_file_path):
-                    with open(stats_file_path, 'w') as writer:
-                        writer.write('{}')
-                with open(stats_file_path, 'r') as reader:
-                    stats = json.load(reader)
-                    if stats.get(prefix):
-                        stats[prefix].update(compilation_stats)
-                    else:
-                        stats[prefix] = compilation_stats
+                modules[f'{module["name"]}@{module["revision"]}'] = module
+            except KeyError:
+                continue
+        return modules
+
+    def _compile_modules(self) -> dict:
+        aggregated_results = {'all': {}, 'no_submodules': {}}
+        try:
+            with open(self.cached_compilation_results_path, 'r') as f:
+                cached_compilation_results = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            cached_compilation_results = {}
+        for yang_file_path in self.yang_list:
+            yang_file_with_revision = self._get_name_with_revision(yang_file_path)
+            if not yang_file_with_revision:
+                continue
+            yang_file_compilation_data = cached_compilation_results.get(yang_file_with_revision)
+            previous_compilation_results = (
+                yang_file_compilation_data.get('compilation_results')
+                if yang_file_compilation_data and isinstance(yang_file_compilation_data, dict)
+                else None
+            )
+            module_hash_info = self.file_hasher.should_parse(yang_file_path)
+            changed_validator_versions = module_hash_info.get_changed_validator_versions(self.validator_versions)
+            if not previous_compilation_results or module_hash_info.hash_changed or changed_validator_versions:
+                parsers_to_use, module_compilation_results = self._get_parsers_to_use_and_previous_compilation_results(
+                    previous_compilation_results,
+                    module_hash_info,
+                    changed_validator_versions,
+                )
+                compilation_status, module_compilation_results = self._parse_module(
+                    parsers_to_use,
+                    yang_file_path,
+                    **self.parser_args,
+                    previous_compilation_results=module_compilation_results,
+                )
+                metadata_generator = self.metadata_generator_cls(
+                    module_compilation_results,
+                    compilation_status,
+                    yang_file_path,
+                    self.documents_dict,
+                )
+                confd_metadata = metadata_generator.get_confd_metadata()
+                yang_file_compilation_data = metadata_generator.get_file_compilation()
+                check_yangcatalog_data(
+                    self.config,
+                    yang_file_path,
+                    confd_metadata,
+                    module_compilation_results,
+                    self.modules,
+                    self.ietf,
+                )
+                # Revert to previous hash if compilation status is 'UNKNOWN' -> try to parse model again next time
+                if compilation_status != 'UNKNOWN':
+                    self.file_hasher.updated_hashes[yang_file_path] = {
+                        'hash': module_hash_info.hash,
+                        'validator_versions': self.validator_versions,
+                    }
+            aggregated_results['all'][yang_file_with_revision] = yang_file_compilation_data
+            if module_or_submodule(yang_file_path) == 'module':
+                aggregated_results['no_submodules'][yang_file_with_revision] = yang_file_compilation_data
+        return aggregated_results
+
+    def _get_name_with_revision(self, yang_file: str) -> str:
+        yang_file_base = os.path.basename(yang_file)
+        out = self._get_mod_rev(yang_file)
+        if out.rstrip():
+            # Add the @revision to the yang_file if not present
+            if '@' in yang_file and '.yang' in yang_file:
+                new_yang_file_base_with_revision = f'{out.rstrip()}.yang'
+                if new_yang_file_base_with_revision.split('@')[0] != yang_file_base.split('@')[0]:
+                    print(
+                        f'Name of the YANG file {yang_file_base} is wrong changing to correct one into '
+                        f'{new_yang_file_base_with_revision}',
+                        flush=True,
+                    )
+                    yang_file_base = new_yang_file_base_with_revision
+                if (
+                    new_yang_file_base_with_revision.split('@')[1].split('.')[0]
+                    != yang_file_base.split('@')[1].split('.')[0]
+                ):
+                    print(
+                        f'Revision of the YANG file {yang_file_base} is wrong changing to correct as '
+                        f'{new_yang_file_base_with_revision}',
+                        flush=True,
+                    )
+                    yang_file_base = new_yang_file_base_with_revision
+                return yang_file_base
+            else:
+                new_yang_file_base_with_revision = f'{out.rstrip()}.yang'
+                if self.debug_level > 0:
+                    print(
+                        f'DEBUG: Adding the revision to YANG module because xym can\'t get revision '
+                        f'(missing from the YANG module): {yang_file}',
+                    )
+                    print(f'DEBUG:  out: {new_yang_file_base_with_revision}')
+                return new_yang_file_base_with_revision
+        print(f'Unable to get name@revision out of {yang_file} - no output', flush=True)
+        return ''
+
+    def _get_mod_rev(self, yang_file) -> str:
+        name = ''
+        revision = ''
+        with open(yang_file, 'r', encoding='utf-8', errors='ignore') as module:
+            for line in module:
+                if name and revision:
+                    return f'{name}@{revision}'
+                if name == '':
+                    match = re.search(r'^\s*(sub)?module\s+([\w\-\d]+)', line)
+                    if match:
+                        name = match.group(2).strip()
+                        continue
+                if not revision:
+                    match = re.search(r'^\s*revision\s+"?([\d\-]+)"?', line)
+                    if match:
+                        revision = match.group(1).strip()
+                        continue
+        return f'{name}@{revision}' if revision else name
+
+    def _get_parsers_to_use_and_previous_compilation_results(
+        self,
+        previous_compilation_results: dict,
+        module_hash_info: FileHasher.ModuleHashCheckForParsing,
+        changed_validator_versions: list[str],
+    ) -> tuple[dict, dict]:
+        if previous_compilation_results and not module_hash_info.hash_changed and changed_validator_versions:
+            parsers_to_use = {
+                parser_name: parser_object
+                for parser_name, parser_object in self.parsers.items()
+                if parser_name in changed_validator_versions
+            }
+            return parsers_to_use, previous_compilation_results
+        return self.parsers, {}
+
+    def _parse_module(
+        self,
+        parsers: dict,
+        yang_file: str,
+        root_directory: str,
+        lint: bool,
+        allinclusive: bool,
+        previous_compilation_results: t.Optional[dict] = None,
+    ) -> tuple[str, dict]:
+        module_compilation_results = previous_compilation_results or {}
+        if pyang_parser := parsers.get('pyang'):
+            module_compilation_results['pyang_lint'] = pyang_parser.run_pyang(
+                root_directory,
+                yang_file,
+                lint,
+                allinclusive,
+                True,
+            )
+            module_compilation_results['pyang'] = pyang_parser.run_pyang(
+                root_directory,
+                yang_file,
+                lint,
+                allinclusive,
+                False,
+            )
+        if confd_parser := parsers.get('confdc'):
+            module_compilation_results['confdrc'] = confd_parser.run_confdc(yang_file, root_directory, allinclusive)
+        if yuma_parser := parsers.get('yangdumppro'):
+            module_compilation_results['yumadump'] = yuma_parser.run_yumadumppro(
+                yang_file,
+                root_directory,
+                allinclusive,
+            )
+        if yanglint_parser := parsers.get('yanglint'):
+            module_compilation_results['yanglint'] = yanglint_parser.run_yanglint(
+                yang_file,
+                root_directory,
+                allinclusive,
+            )
+        compilation_status = combined_compilation(os.path.basename(yang_file), module_compilation_results)
+        return compilation_status, module_compilation_results
+
+    def _generate_compilation_files(self):
+        self.files_generator.write_dictionary(self.aggregated_results['all'], self.prefix)
+        headers = self.files_generator.get_yang_page_compilation_headers(self.lint)
+        self.files_generator.generate_yang_page_compilation_html(
+            self.aggregated_results['no_submodules'],
+            headers,
+            self.prefix,
+            self.metadata,
+        )
+
+    def _generate_statistics_page(self) -> dict:
+        passed = number_that_passed_compilation(self.aggregated_results['all'], 0, 'PASSED')
+        passed_with_warnings = number_that_passed_compilation(self.aggregated_results['all'], 0, 'PASSED WITH WARNINGS')
+        total_number = len(self.yang_list)
+        failed = total_number - passed - passed_with_warnings
+        compilation_stats = {
+            'passed': passed,
+            'warnings': passed_with_warnings,
+            'total': total_number,
+            'failed': failed,
+        }
+        self._write_page_main(self.prefix, compilation_stats)
+        self.files_generator.generate_yang_page_main_html(self.prefix, compilation_stats)
+        return compilation_stats
+
+    def _write_page_main(self, prefix: str, compilation_stats: dict) -> dict:  # pyright: ignore
+        stats_directory = os.path.join(self.web_private, 'stats')
+        os.makedirs(stats_directory, exist_ok=True)
+        with FileLock(os.path.join(stats_directory, 'stats.json.lock')):
+            stats_file_path = os.path.join(stats_directory, 'AllYANGPageMain.json')
+            if not os.path.exists(stats_file_path):
                 with open(stats_file_path, 'w') as writer:
-                    json.dump(stats, writer)
-                return stats[prefix]
-            # NOTE: what kind of exception is expected here?
-            except Exception:
-                counter = counter - 1
-                if counter == 0:
-                    break
+                    writer.write('{}')
+            with open(stats_file_path, 'r') as reader:
+                stats = json.load(reader)
+                if stats.get(prefix):
+                    stats[prefix].update(compilation_stats)
+                else:
+                    stats[prefix] = compilation_stats
+            with open(stats_file_path, 'w') as writer:
+                json.dump(stats, writer)
+            return stats[prefix]
+
+    def _print_compilation_results_summary(self, compilation_stats: dict):
+        print(f'Number of YANG data models from {self.prefix}: {compilation_stats["total"]}')
+        print(
+            f'Number of YANG data models from {self.prefix} that passed compilation: '
+            f'{compilation_stats["passed"]}/{compilation_stats["total"]}',
+        )
+        print(
+            f'Number of YANG data models from {self.prefix} that passed compilation with warnings: '
+            f'{compilation_stats["warnings"]}/{compilation_stats["total"]}',
+        )
+        print(
+            f'Number of YANG data models from {self.prefix} that failed compilation: '
+            f'{compilation_stats["failed"]}/{compilation_stats["total"]}',
+        )
+
+
+class CompileBaseModules(CompileModulesABC):
+    ietf = None
+    metadata_generator_cls = BaseMetadataGenerator
+
+    def __init__(self, prefix: str, root_dir: str, options: CompileModulesABC.Options):
+        self.prefix = prefix
+        super().__init__(options)
+        self.root_dir = root_dir
+        self.documents_dict = {}
+
+
+class CompileRfcModules(CompileModulesABC):
+    ietf = IETF.RFC
+    metadata_generator_cls = RfcMetadataGenerator
+    prefix = 'RFCStandard'
+
+    def __init__(self, options: CompileModulesABC.Options):
+        super().__init__(options)
+        self.root_dir = os.path.join(self.ietf_directory, 'YANG-rfc')
+        with open(os.path.join(self.cache_directory, 'rfc_dict.json')) as f:
+            self.documents_dict = json.load(f)
+
+    def _generate_compilation_files(self):
+        # Create yang module reference table
+        module_to_rfc_anchor = {}
+        for yang_module, document_name in self.documents_dict.items():
+            rfc_name = document_name.split('.')[0]
+            datatracker_url = f'https://datatracker.ietf.org/doc/html/{rfc_name}'
+            rfc_url_anchor = f'<a href="{datatracker_url}">{rfc_name}</a>'
+            module_to_rfc_anchor[yang_module] = rfc_url_anchor
+        self.files_generator.write_dictionary(module_to_rfc_anchor, 'IETFYANGRFC')
+        headers = ['YANG Model (and submodel)', 'RFC']
+        self.files_generator.generate_html_table(module_to_rfc_anchor, headers)
+        super()._generate_compilation_files()
+
+
+class CompileDraftModules(CompileModulesABC):
+    ietf = IETF.DRAFT
+    metadata_generator_cls = DraftMetadataGenerator
+    prefix = 'IETFDraft'
+    compilation_status_position = 3
+
+    def __init__(self, options: CompileModulesABC.Options):
+        super().__init__(options)
+        self.root_dir = os.path.join(self.ietf_directory, 'YANG')
+        with open(os.path.join(self.cache_directory, 'draft_dict.json')) as f:
+            self.documents_dict = json.load(f)
+        self.cached_compilation_results_path = os.path.join(self.web_private, 'IETFCiscoAuthors.json')
+
+    def _generate_compilation_files(self):
+        # Generate json and html files with compilation results of modules extracted from IETF Drafts with Cisco authors
+        self.files_generator.write_dictionary(self.aggregated_results['all'], 'IETFCiscoAuthors')
+        headers = self.files_generator.get_ietf_cisco_authors_yang_page_compilation_headers()
+        self.files_generator.generate_yang_page_compilation_html(
+            self.aggregated_results['all'],
+            headers,
+            'IETFCiscoAuthors',
+        )
+        # Update draft archive cache
+        path = os.path.join(self.web_private, 'IETFDraftArchive.json')
+        try:
+            with open(path) as f:
+                old_draft_archive_results = json.load(f)
+        except FileNotFoundError:
+            old_draft_archive_results = {}
+        draft_archive_results = old_draft_archive_results | self.aggregated_results['all']
+        self.files_generator.write_dictionary(draft_archive_results, 'IETFDraftArchive')
+        # Strip cisco authors out
+        for module_data in self.aggregated_results['all'].values():
+            compilation_metadata = module_data['compilation_metadata']
+            module_data['compilation_metadata'] = compilation_metadata[:2] + compilation_metadata[3:]
+        # Generate json and html files with compilation results of modules extracted from IETF Drafts
+        self.files_generator.write_dictionary(self.aggregated_results['all'], self.prefix)
+        headers = self.files_generator.get_ietf_draft_yang_page_compilation_headers()
+        self.files_generator.generate_yang_page_compilation_html(self.aggregated_results['all'], headers, self.prefix)
+
+    def _generate_statistics_page(self) -> dict:
+        all_yang_path = os.path.join(self.ietf_directory, 'YANG-all')
+        compilation_stats = {
+            'total-drafts': len(self.documents_dict),
+            'draft-passed': number_that_passed_compilation(
+                self.aggregated_results['all'],
+                self.compilation_status_position,
+                'PASSED',
+            ),
+            'draft-warnings': number_that_passed_compilation(
+                self.aggregated_results['all'],
+                self.compilation_status_position,
+                'PASSED WITH WARNINGS',
+            ),
+            'all-ietf-drafts': len(
+                [f for f in os.listdir(all_yang_path) if os.path.isfile(os.path.join(all_yang_path, f))],
+            ),
+        }
+        merged_stats = self._write_page_main('ietf-yang', compilation_stats)
+        self.files_generator.generate_ietfyang_page_main_html(merged_stats)
+        return compilation_stats
+
+    def _print_compilation_results_summary(self, compilation_stats: dict):
+        print(f'Number of correctly extracted YANG models from IETF drafts: {compilation_stats["total-drafts"]}')
+        print(
+            'Number of YANG models in IETF drafts that passed compilation: '
+            f'{compilation_stats["draft-passed"]}/{compilation_stats.get("total-drafts")}',
+        )
+        print(
+            'Number of YANG models in IETF drafts that passed compilation with warnings: '
+            f'{compilation_stats["draft-warnings"]}/{compilation_stats.get("total-drafts")}',
+        )
+        print(
+            'Number of all YANG models in IETF drafts (examples, badly formatted, etc. ): '
+            f'{compilation_stats["all-ietf-drafts"]}',
+        )
+
+
+class CompileDraftArchiveModules(CompileDraftModules):
+    ietf = IETF.DRAFT_ARCHIVE
+    metadata_generator_cls = ArchivedMetadataGenerator
+    prefix = 'IETFDraftArchive'
+    compilation_status_position = 4
+
+    def _generate_compilation_files(self):
+        self.files_generator.write_dictionary(self.aggregated_results['all'], self.prefix)
+        path = os.path.join(self.web_private, 'IETFCiscoAuthors.json')
+        try:
+            with open(path) as f:
+                old_draft_results = json.load(f)
+        except FileNotFoundError:
+            old_draft_results = {}
+        draft_results = old_draft_results | self.aggregated_results['all']
+        self.files_generator.write_dictionary(draft_results, 'IETFCiscoAuthors')
+
+
+class CompileExampleModules(CompileModulesABC):
+    ietf = IETF.EXAMPLE
+    metadata_generator_cls = ExampleMetadataGenerator
+    prefix = 'IETFDraftExample'
+
+    def __init__(self, options: CompileModulesABC.Options):
+        super().__init__(options)
+        self.root_dir = os.path.join(self.ietf_directory, 'YANG-example')
+        with open(os.path.join(self.cache_directory, 'example_dict.json')) as f:
+            self.documents_dict = json.load(f)
+
+    def _parse_module(
+        self,
+        parsers: dict,
+        yang_file: str,
+        root_directory: str,
+        lint: bool,
+        allinclusive: bool,
+        previous_compilation_results: t.Optional[dict] = None,
+    ) -> tuple[str, dict]:
+        module_compilation_results = previous_compilation_results or {}
+        if pyang_parser := parsers.get('pyang'):
+            module_compilation_results['pyang_lint'] = pyang_parser.run_pyang(
+                root_directory,
+                yang_file,
+                lint,
+                allinclusive,
+                True,
+            )
+            module_compilation_results['pyang'] = pyang_parser.run_pyang(
+                root_directory,
+                yang_file,
+                lint,
+                allinclusive,
+                False,
+            )
+        compilation_status = pyang_compilation_status(module_compilation_results['pyang_lint'])
+        return compilation_status, module_compilation_results
+
+    def _generate_compilation_files(self):
+        self.files_generator.write_dictionary(self.aggregated_results['all'], self.prefix)
+        headers = self.files_generator.get_ietf_draft_example_yang_page_compilation_headers()
+        self.files_generator.generate_yang_page_compilation_html(
+            self.aggregated_results['no_submodules'],
+            headers,
+            self.prefix,
+        )
+
+    def _generate_statistics_page(self) -> dict:
+        compilation_stats = {'example-drafts': len(self.documents_dict)}
+        merged_stats = self._write_page_main('ietf-yang', compilation_stats)
+        self.files_generator.generate_ietfyang_page_main_html(merged_stats)
+        return compilation_stats
+
+    def _print_compilation_results_summary(self, compilation_stats: dict):
+        print(
+            'Number of correctly extracted example YANG models from IETF drafts: '
+            f'{compilation_stats["example-drafts"]}',
+            flush=True,
+        )
 
 
 def main():
-    global config, debug_level, file_hasher, ietf, metadata_generator_cls, web_private
     config = create_config()
-    yangcatalog_api_prefix = config.get('Web-Section', 'yangcatalog-api-prefix')
-    web_private = config.get('Web-Section', 'private-directory') + '/'
-    cache_directory = config.get('Directory-Section', 'cache')
     modules_directory = config.get('Directory-Section', 'modules-directory')
-    temp_dir = config.get('Directory-Section', 'temp')
-    ietf_directory = config.get('Directory-Section', 'ietf-directory')
-
     parser = argparse.ArgumentParser(
         description='YANG Document Processor: generate tables with compilation errors/warnings',
     )
@@ -391,9 +597,9 @@ def main():
     )
     parser.add_argument(
         '--allinclusive',
-        help='Optional flag that determines whether the rootdir directory '
+        help='Optional flag that determines whether the root_dir directory '
         'contains all imported YANG modules; '
-        'If set, the YANG validators will only look in the rootdir directory. '
+        'If set, the YANG validators will only look in the root_dir directory. '
         f'Otherwise, the YANG validators look in {modules_directory}. '
         'Default is False',
         action='store_true',
@@ -433,215 +639,25 @@ def main():
         action='store_true',
     )
     args = parser.parse_args()
-
-    # Set options depending on the type of documents we're compiling
-    if not any([args.draft, args.draft_archive, args.example, args.rfc]):
-        ietf = None
-        metadata_generator_cls = BaseMetadataGenerator
-        document_dict = {}
-    elif args.rfc:
-        ietf = IETF.RFC
-        metadata_generator_cls = RfcMetadataGenerator
-        with open(os.path.join(cache_directory, 'rfc_dict.json')) as f:
-            document_dict = json.load(f)
-        args.prefix = 'RFCStandard'
-        args.rootdir = os.path.join(ietf_directory, 'YANG-rfc')
-    elif args.draft or args.draft_archive:
-        if args.draft_archive:
-            ietf = IETF.DRAFT_ARCHIVE
-            metadata_generator_cls = ArchivedMetadataGenerator
-            args.prefix = 'IETFDraftArchive'
-        else:
-            ietf = IETF.DRAFT
-            metadata_generator_cls = DraftMetadataGenerator
-            args.prefix = 'IETFDraft'
-        with open(os.path.join(cache_directory, 'draft_dict.json')) as f:
-            document_dict = json.load(f)
-        args.rootdir = os.path.join(ietf_directory, 'YANG')
-    elif args.example:
-        ietf = IETF.EXAMPLE
-        metadata_generator_cls = ExampleMetadataGenerator
-        with open(os.path.join(cache_directory, 'example_dict.json')) as f:
-            document_dict = json.load(f)
-        args.prefix = 'IETFDraftExample'
-        args.rootdir = os.path.join(ietf_directory, 'YANG-example')
-    else:
-        raise RuntimeError('Incorrect ietf arg')
-
-    custom_print(f'Start of job in {args.rootdir}')
-
-    debug_level = args.debug
-
-    # Get list of hashed files
-    file_hasher = FileHasher(force_compilation=args.forcecompilation, config=config)
-
-    modules = get_modules(temp_dir, yangcatalog_api_prefix)
-
-    yang_list = list_files_by_extensions(
-        args.rootdir,
-        ('yang',),
-        return_full_paths=True,
-        recursive=True,
+    options = CompileModulesABC.Options(
         debug_level=args.debug,
+        force_compilation=args.forcecompilation,
+        lint=args.lint,
+        allinclusive=args.allinclusive,
+        metadata=args.metadata,
+        config=config,
     )
-
-    parser_args = {'root_directory': args.rootdir, 'lint': args.lint, 'allinclusive': args.allinclusive}
-
-    if debug_level > 0:
-        print(f'yang_list content:\n{yang_list}')
-    custom_print(f'relevant files list built, {len(yang_list)} modules found in {args.rootdir}')
-    aggregate_results = validate(args.prefix, modules, yang_list, parser_args, document_dict, config)
-    custom_print('all modules compiled/validated')
-
-    # Generate HTML and JSON files
-    files_generator = FilesGenerator(web_private)
-    if ietf == IETF.DRAFT:
-        # Generate json and html files with compilation results of modules extracted from IETF Drafts with Cisco authors
-        files_generator.write_dictionary(aggregate_results['all'], 'IETFCiscoAuthors')
-        headers = files_generator.get_ietf_cisco_authors_yang_page_compilation_headers()
-        files_generator.generate_yang_page_compilation_html(aggregate_results['all'], headers, 'IETFCiscoAuthors')
-
-        # Update draft archive cache
-        path = os.path.join(web_private, 'IETFDraftArchive.json')
-        try:
-            with open(path) as f:
-                old_draft_archive_results = json.load(f)
-        except FileNotFoundError:
-            old_draft_archive_results = {}
-        draft_archive_results = old_draft_archive_results | aggregate_results['all']
-        files_generator.write_dictionary(draft_archive_results, 'IETFDraftArchive')
-
-        # Strip cisco authors out
-        for module_data in aggregate_results['all'].values():
-            compilation_metadata = module_data['compilation_metadata']
-            module_data['compilation_metadata'] = compilation_metadata[:2] + compilation_metadata[3:]
-
-        # Generate json and html files with compilation results of modules extracted from IETF Drafts
-        files_generator.write_dictionary(aggregate_results['all'], args.prefix)
-        headers = files_generator.get_ietf_draft_yang_page_compilation_headers()
-        files_generator.generate_yang_page_compilation_html(aggregate_results['all'], headers, args.prefix)
-    elif ietf == IETF.DRAFT_ARCHIVE:
-        files_generator.write_dictionary(aggregate_results['all'], args.prefix)
-
-        # Update draft cache
-        path = os.path.join(web_private, 'IETFCiscoAuthors.json')
-        try:
-            with open(path) as f:
-                old_draft_results = json.load(f)
-        except FileNotFoundError:
-            old_draft_results = {}
-        draft_results = old_draft_results | aggregate_results['all']
-        files_generator.write_dictionary(draft_results, 'IETFCiscoAuthors')
-    elif ietf == IETF.EXAMPLE:
-        files_generator.write_dictionary(aggregate_results['all'], args.prefix)
-        headers = files_generator.get_ietf_draft_example_yang_page_compilation_headers()
-        files_generator.generate_yang_page_compilation_html(aggregate_results['no_submodules'], headers, args.prefix)
+    if args.rfc:
+        compile_modules_script = CompileRfcModules(options)
+    elif args.draft:
+        compile_modules_script = CompileDraftModules(options)
+    elif args.draft_archive:
+        compile_modules_script = CompileDraftArchiveModules(options)
+    elif args.example:
+        compile_modules_script = CompileExampleModules(options)
     else:
-        if ietf == IETF.RFC:
-            # Create yang module reference table
-            module_to_rfc_anchor = {}
-            for yang_module, document_name in document_dict.items():
-                rfc_name = document_name.split('.')[0]
-                datatracker_url = f'https://datatracker.ietf.org/doc/html/{rfc_name}'
-                rfc_url_anchor = f'<a href="{datatracker_url}">{rfc_name}</a>'
-                module_to_rfc_anchor[yang_module] = rfc_url_anchor
-
-            files_generator.write_dictionary(module_to_rfc_anchor, 'IETFYANGRFC')
-            headers = ['YANG Model (and submodel)', 'RFC']
-            files_generator.generate_html_table(module_to_rfc_anchor, headers)
-
-        files_generator.write_dictionary(aggregate_results['all'], args.prefix)
-        headers = files_generator.get_yang_page_compilation_headers(args.lint)
-        files_generator.generate_yang_page_compilation_html(
-            aggregate_results['no_submodules'],
-            headers,
-            args.prefix,
-            args.metadata,
-        )
-
-    # Generate modules compilation results statistics HTML page
-    if ietf in (IETF.DRAFT, IETF.DRAFT_ARCHIVE):
-        all_yang_path = os.path.join(ietf_directory, 'YANG-all')
-        compilation_status_position = 3 if ietf == IETF.DRAFT else 4
-        compilation_stats = {
-            'total-drafts': len(document_dict),
-            'draft-passed': number_that_passed_compilation(
-                aggregate_results['all'],
-                compilation_status_position,
-                'PASSED',
-            ),
-            'draft-warnings': number_that_passed_compilation(
-                aggregate_results['all'],
-                compilation_status_position,
-                'PASSED WITH WARNINGS',
-            ),
-            'all-ietf-drafts': len(
-                [f for f in os.listdir(all_yang_path) if os.path.isfile(os.path.join(all_yang_path, f))],
-            ),
-        }
-        merged_stats = write_page_main('ietf-yang', compilation_stats)
-        files_generator.generate_ietfyang_page_main_html(merged_stats)
-    elif ietf == IETF.EXAMPLE:
-        compilation_stats = {'example-drafts': len(document_dict.keys())}
-        merged_stats = write_page_main('ietf-yang', compilation_stats)
-        files_generator.generate_ietfyang_page_main_html(merged_stats)
-    else:
-        passed = number_that_passed_compilation(aggregate_results['all'], 0, 'PASSED')
-        passed_with_warnings = number_that_passed_compilation(aggregate_results['all'], 0, 'PASSED WITH WARNINGS')
-        total_number = len(yang_list)
-        failed = total_number - passed - passed_with_warnings
-        compilation_stats = {
-            'passed': passed,
-            'warnings': passed_with_warnings,
-            'total': total_number,
-            'failed': failed,
-        }
-        write_page_main(args.prefix, compilation_stats)
-        files_generator.generate_yang_page_main_html(args.prefix, compilation_stats)
-
-    _print_compilation_results_summary(args.prefix, ietf, compilation_stats)
-    custom_print(f'end of {os.path.basename(__file__)} job for {args.prefix}')
-
-    # Update files content hashes and dump into .json file
-    file_hasher.dump_hashed_files_list()
-
-
-def _print_compilation_results_summary(files_prefix: str, ietf: IETF, compilation_stats: dict):
-    print('--------------------------')
-    if ietf in (IETF.DRAFT, IETF.DRAFT_ARCHIVE):
-        print(f'Number of correctly extracted YANG models from IETF drafts: {compilation_stats["total-drafts"]}')
-        print(
-            'Number of YANG models in IETF drafts that passed compilation: '
-            f'{compilation_stats["draft-passed"]}/{compilation_stats.get("total-drafts")}',
-        )
-        print(
-            'Number of YANG models in IETF drafts that passed compilation with warnings: '
-            f'{compilation_stats["draft-warnings"]}/{compilation_stats.get("total-drafts")}',
-        ),
-        print(
-            'Number of all YANG models in IETF drafts (examples, badly formatted, etc. ): '
-            f'{compilation_stats["all-ietf-drafts"]}',
-        )
-    elif ietf == IETF.EXAMPLE:
-        print(
-            'Number of correctly extracted example YANG models from IETF drafts: '
-            f'{compilation_stats["example-drafts"]}',
-            flush=True,
-        )
-    else:
-        print(f'Number of YANG data models from {files_prefix}: {compilation_stats["total"]}')
-        print(
-            f'Number of YANG data models from {files_prefix} that passed compilation: '
-            f'{compilation_stats["passed"]}/{compilation_stats["total"]}',
-        )
-        print(
-            f'Number of YANG data models from {files_prefix} that passed compilation with warnings: '
-            f'{compilation_stats["warnings"]}/{compilation_stats["total"]}',
-        )
-        print(
-            f'Number of YANG data models from {files_prefix} that failed compilation: '
-            f'{compilation_stats["failed"]}/{compilation_stats["total"]}',
-        )
+        compile_modules_script = CompileBaseModules(args.prefix, args.rootdir, options)
+    compile_modules_script()
 
 
 if __name__ == '__main__':

--- a/modules_compilation/compile_modules.py
+++ b/modules_compilation/compile_modules.py
@@ -385,8 +385,6 @@ class CompileModulesABC(abc.ABC):
             self.metadata,
         )
 
-    # def _save_compilation_results_hash
-
     def _generate_statistics_page(self) -> dict:
         passed = number_that_passed_compilation(self.aggregated_results['all'], 0, 'PASSED')
         passed_with_warnings = number_that_passed_compilation(self.aggregated_results['all'], 0, 'PASSED WITH WARNINGS')

--- a/modules_compilation/compile_modules.py
+++ b/modules_compilation/compile_modules.py
@@ -71,6 +71,20 @@ class CompileModulesABC(abc.ABC):
         save_compilation_results_to_db: bool
         config: ConfigParser = create_config()
 
+    @dataclass
+    class ModuleInfoForCompilation:
+        yang_file_path: str
+        module_hash: str
+        module_hash_changed: bool
+        changed_validator_versions: t.Optional[list[str]]
+        yang_file_compilation_data: t.Optional[dict]
+        previous_compilation_results: t.Optional[dict]
+
+    class ModuleCachedCompilationResult(t.TypedDict):
+        yang_file_path: t.Optional[str]  # could be missing
+        compilation_metadata: tuple[str, ...]
+        compilation_results: dict[str, str]
+
     def __init__(self, options: Options):
         self.config = options.config
         self.yangcatalog_api_prefix = self.config.get('Web-Section', 'yangcatalog-api-prefix')
@@ -79,6 +93,7 @@ class CompileModulesABC(abc.ABC):
         self.modules_directory = self.config.get('Directory-Section', 'modules-directory')
         self.temp_dir = self.config.get('Directory-Section', 'temp')
         self.ietf_directory = self.config.get('Directory-Section', 'ietf-directory')
+        self.all_modules_dir = self.config.get('Directory-Section', 'save-file-dir')
         self.cached_compilation_results_path = os.path.join(self.web_private, f'{self.prefix}.json')
 
         self.debug_level = options.debug_level
@@ -114,6 +129,14 @@ class CompileModulesABC(abc.ABC):
             print(f'yang_list content:\n{self.yang_list}')
         self._custom_print(f'relevant files list built, {len(self.yang_list)} modules found in {self.root_dir}')
         self.modules = self._get_modules()
+        try:
+            with open(self.cached_compilation_results_path, 'r') as f:
+                self.cached_compilation_results: dict[
+                    str,
+                    CompileModulesABC.ModuleCachedCompilationResult,
+                ] = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            self.cached_compilation_results: dict[str, CompileModulesABC.ModuleCachedCompilationResult] = {}
         self.aggregated_results = self._compile_modules()
         self._custom_print('all modules compiled/validated')
         self._generate_compilation_files()
@@ -146,43 +169,22 @@ class CompileModulesABC(abc.ABC):
 
     def _compile_modules(self) -> dict:
         aggregated_results = {'all': {}, 'no_submodules': {}}
-        try:
-            with open(self.cached_compilation_results_path, 'r') as f:
-                cached_compilation_results = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
-            cached_compilation_results = {}
         for yang_file_path in self.yang_list:
-            yang_file_with_revision = self._get_name_with_revision(yang_file_path)
-            if not yang_file_with_revision:
+            file_name_and_revision = self._get_name_with_revision(yang_file_path)
+            if not file_name_and_revision:
                 continue
-            yang_file_compilation_data = cached_compilation_results.get(yang_file_with_revision)
-            yang_file_compilation_data = yang_file_compilation_data.get('original')
-            # yang_file_compilation_data.get('duplicates')
-            previous_compilation_results = (
-                yang_file_compilation_data.get('compilation_results')
-                if yang_file_compilation_data and isinstance(yang_file_compilation_data, dict)
-                else None
-            )
-            module_hash_info = self.file_hasher.should_parse(yang_file_path)
-            changed_validator_versions = module_hash_info.get_changed_validator_versions(self.validator_versions)
-            # if module_hash_info.hash_changed:
-            #     duplicated_paths = ...
-            #     hash_loaded_from_populated_script = ...
-            #     for path in duplicated_paths:
-            #         duplicate_module_hash_info = self.file_hasher.should_parse(path)
-            #         duplicate_changed_validator_versions = module_hash_info.get_changed_validator_versions(
-            #             self.validator_versions
-            #         )
-            #         if duplicate_module_hash_info.hash == hash_loaded_from_populated_script:
-            #             yang_file_path = path
-            #             module_hash_info = ...
-            #             changed_validator_versions = changed_validator_versions
-            # see what to do if hash not changed but duplicate has the same hash as populated module from populate.py
-            if not previous_compilation_results or module_hash_info.hash_changed or changed_validator_versions:
+            module_info_for_compilation = self._get_module_info_for_compilation(yang_file_path, file_name_and_revision)
+            yang_file_path = module_info_for_compilation.yang_file_path
+            yang_file_compilation_data = module_info_for_compilation.yang_file_compilation_data
+            if (
+                not module_info_for_compilation.previous_compilation_results
+                or module_info_for_compilation.module_hash_changed
+                or module_info_for_compilation.changed_validator_versions
+            ):
                 parsers_to_use, module_compilation_results = self._get_parsers_to_use_and_previous_compilation_results(
-                    previous_compilation_results,
-                    module_hash_info,
-                    changed_validator_versions,
+                    module_info_for_compilation.previous_compilation_results,
+                    module_info_for_compilation.module_hash_changed,
+                    module_info_for_compilation.changed_validator_versions,
                 )
                 compilation_status, module_compilation_results = self._parse_module(
                     parsers_to_use,
@@ -209,13 +211,56 @@ class CompileModulesABC(abc.ABC):
                 # Revert to previous hash if compilation status is 'UNKNOWN' -> try to parse model again next time
                 if compilation_status != 'UNKNOWN':
                     self.file_hasher.updated_hashes[yang_file_path] = {
-                        'hash': module_hash_info.hash,
+                        'hash': module_info_for_compilation.module_hash,
                         'validator_versions': self.validator_versions,
                     }
-            aggregated_results['all'][yang_file_with_revision] = yang_file_compilation_data
+            aggregated_results['all'][file_name_and_revision] = yang_file_compilation_data
             if module_or_submodule(yang_file_path) == 'module':
-                aggregated_results['no_submodules'][yang_file_with_revision] = yang_file_compilation_data
+                aggregated_results['no_submodules'][file_name_and_revision] = yang_file_compilation_data
         return aggregated_results
+
+    def _get_module_info_for_compilation(
+        self,
+        yang_file_path: str,
+        file_name_and_revision: str,
+    ) -> ModuleInfoForCompilation:
+        all_modules_dir_yang_file_path = os.path.join(self.all_modules_dir, file_name_and_revision)
+        all_modules_dir_yang_file_hash_info = (
+            self.file_hasher.should_parse(all_modules_dir_yang_file_path)
+            if os.path.exists(all_modules_dir_yang_file_path)
+            else None
+        )
+        yang_file_compilation_data = self.cached_compilation_results.get(file_name_and_revision, {})
+        module_hash_info = self.file_hasher.should_parse(yang_file_path)
+        if all_modules_dir_yang_file_hash_info:
+            if yang_file_compilation_data.get('yang_file_path') == all_modules_dir_yang_file_path:
+                # the file has been already re-compiled with the path in all_modules_dir
+                # so this path is the right one for this file compilation
+                yang_file_path = all_modules_dir_yang_file_path
+                module_hash_info = all_modules_dir_yang_file_hash_info
+            elif module_hash_info.hash != all_modules_dir_yang_file_hash_info.hash:
+                # the file in yang_file_path isn't the right one
+                # and should be re-compiled with the path in all_modules_dir
+                return self.ModuleInfoForCompilation(
+                    yang_file_path=all_modules_dir_yang_file_path,
+                    module_hash=all_modules_dir_yang_file_hash_info.hash,
+                    module_hash_changed=True,
+                    changed_validator_versions=None,
+                    yang_file_compilation_data=None,
+                    previous_compilation_results=None,
+                )
+        return self.ModuleInfoForCompilation(
+            yang_file_path=yang_file_path,
+            module_hash=module_hash_info.hash,
+            module_hash_changed=module_hash_info.hash_changed,
+            changed_validator_versions=module_hash_info.get_changed_validator_versions(self.validator_versions),
+            yang_file_compilation_data=yang_file_compilation_data,
+            previous_compilation_results=(
+                yang_file_compilation_data.get('compilation_results')
+                if yang_file_compilation_data and isinstance(yang_file_compilation_data, dict)
+                else None
+            ),
+        )
 
     def _get_name_with_revision(self, yang_file: str) -> str:
         yang_file_base = os.path.basename(yang_file)
@@ -275,11 +320,11 @@ class CompileModulesABC(abc.ABC):
 
     def _get_parsers_to_use_and_previous_compilation_results(
         self,
-        previous_compilation_results: dict,
-        module_hash_info: FileHasher.ModuleHashCheckForParsing,
-        changed_validator_versions: list[str],
+        previous_compilation_results: t.Optional[dict],
+        module_hash_changed: bool,
+        changed_validator_versions: t.Optional[list[str]],
     ) -> tuple[dict, dict]:
-        if previous_compilation_results and not module_hash_info.hash_changed and changed_validator_versions:
+        if previous_compilation_results and not module_hash_changed and changed_validator_versions:
             parsers_to_use = {
                 parser_name: parser_object
                 for parser_name, parser_object in self.parsers.items()
@@ -583,18 +628,6 @@ class CompileExampleModules(CompileModulesABC):
             f'{compilation_stats["example-drafts"]}',
             flush=True,
         )
-
-
-class CompileAllSavedModules(CompileModulesABC):
-    d = {
-        IETF.RFC: {},
-    }
-
-    def __init__(self, options: CompileModulesABC.Options):
-        super().__init__(options)
-        self.root_dir = options.config.get('Directory-Section', 'save-file-dir')
-        with open(os.path.join(self.cache_directory, 'example_dict.json')) as f:
-            self.documents_dict = json.load(f)
 
 
 def main():

--- a/modules_compilation/file_hasher.py
+++ b/modules_compilation/file_hasher.py
@@ -48,13 +48,12 @@ class FileHasher:
 
     def hash_file(self, path: str) -> str:
         """
-        Create hash from content of the given file and validators versions.
-        Each time either the content of the file or the validator version change,
+        Create hash from content of the given file. Each time the content of the file change,
         the resulting hash will be different.
 
-        :param path     (str) Path fo file to be hashed
-        :return         SHA256 hash of the content of the given file
-        :rtype          str
+        Arguments:
+            :param path (str) Path fo file to be hashed
+        :return (str) SHA256 hash of the content of the given file
         """
         file_hash = hashlib.sha256()
         with open(path, 'rb') as reader:

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -223,7 +223,6 @@ class TestUtility(TestUtilityBase):
             module_data=module_data,
             compilation_results=compilation_results,
             result_html_dir=result_dir,
-            is_rfc=False,
             versions=validator_versions,
         )
         self.assertEqual(file_url, filename)


### PR DESCRIPTION
Running the ```compile_modules.py``` script again after a run of the ```populate.py``` script will not help because statistics and other generated files won't be overwritten because of lack of information for them (or managing their upload will not be straightforward at all as we have to manage different ietf arguments and they all have specific logic), so I decided to check the ```/var/yang/all_modules``` directory inside the ```compile_modules.py``` script, so if the file is already in the ```/var/yang/all_modules``` and the hash of the file that is being processed at the moment is different from the hash of the file inside the ```/var/yang/all_modules```, we will compile the file from the ```/var/yang/all_modules``` dir, as it's always the actual file. I didn't remove updating of Redis from the ```compile_modules.py``` script because if this case happens, then the actual compilation data will be set to Redis after the next run of ```compile_modules.py```

resolves #248 