### PR TITLE
feat: extract archive drafts only on xym version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN sed -i "s|<MAIL_TO>|${CRON_MAIL_TO}|g" /etc/cron.d/ietf-cron
 RUN sed -i "s|<YANGCATALOG_CONFIG_PATH>|${YANGCATALOG_CONFIG_PATH}|g" /etc/cron.d/ietf-cron
 RUN sed -i "s|<VIRTUAL_ENV>|${VIRTUAL_ENV}|g" /etc/cron.d/ietf-cron
 RUN sed -i "s|<CONF>|${CONF}|g" /etc/cron.d/ietf-cron
+RUN sed -i "s|<XYM_VERSION>|${XYM_VERSION}|g" /etc/cron.d/ietf-cron
 RUN sed -i "/imklog/s/^/#/" /etc/rsyslog.conf
 
 RUN rm -rf /usr/bin/python

--- a/conf/paths.sh
+++ b/conf/paths.sh
@@ -32,6 +32,8 @@ IS_PROD=$(python "$VIRTUAL_ENV"/get_config.py --section General-Section --key is
 export IS_PROD
 GIT_TOKEN=$(python "$VIRTUAL_ENV"/get_config.py --section Secrets-Section --key yang-catalog-token)
 export GIT_TOKEN
+LATEST_XYM_VERSION_FILE=$(python "$VIRTUAL_ENV"/get_config.py --section Directory-Section --key modules-extraction-latest-xym-version)
+export LATEST_XYM_VERSION_FILE
 
 #
 # Repositories

--- a/crontab
+++ b/crontab
@@ -3,6 +3,7 @@ SHELL=/bin/bash
 YANGCATALOG_CONFIG_PATH=<YANGCATALOG_CONFIG_PATH>
 VIRTUAL_ENV=<VIRTUAL_ENV>
 CONF=<CONF>
+XYM_VERSION=<XYM_VERSION>
 #
 # For more information see the manual pages of crontab(5) and cron(8)
 #

--- a/ietf_modules_extraction/run_ietf_module_extraction.sh
+++ b/ietf_modules_extraction/run_ietf_module_extraction.sh
@@ -103,8 +103,21 @@ ln -f -s "$NONIETFDIR"/yangmodels/yang/standard/iana/ "$MODULES"/iana
 
 # Extract all YANG models from RFC and I-D
 date +"%c: Starting to extract all YANG modules from IETF documents" >>"$LOG"
-# Using --draftpath "$IETFDIR"/my-id-archive-mirror/ means much longer process as all expired drafts will also be analyzed...
-if [ "$(date +%u)" -eq 6 ]; then
+if [ -f "$LATEST_XYM_VERSION_FILE" ] && [ -s "$LATEST_XYM_VERSION_FILE" ]; then
+  if ! grep -Fxq "$XYM_VERSION" "$LATEST_XYM_VERSION_FILE"; then
+    truncate -s 0 "$LATEST_XYM_VERSION_FILE"
+    echo "$XYM_VERSION" > "$LATEST_XYM_VERSION_FILE"
+    XYM_VERSION_IS_UPDATED=true
+  else
+    XYM_VERSION_IS_UPDATED=false
+  fi
+else
+  # this situation can only happen during the PROD update at the first time with these changes
+  echo "$XYM_VERSION" > "$LATEST_XYM_VERSION_FILE"
+  XYM_VERSION_IS_UPDATED=false
+fi
+if [ "$XYM_VERSION_IS_UPDATED" = true ] && [ "$IS_PROD" = "True" ]; then
+  # Using --archived  means much longer process as all expired drafts will also be analyzed...
 	python "$VIRTUAL_ENV"/ietf_modules_extraction/extract_ietf_modules.py --archived >>"$LOG" 2>&1
 fi
 python "$VIRTUAL_ENV"/ietf_modules_extraction/extract_ietf_modules.py >>"$LOG" 2>&1


### PR DESCRIPTION
From now on, archive drafts extraction will only be executed after a new xym release, so we don't re-extract it every week because it's time-consuming  and doesn't actually make sense since the xym version stays the same and all the archived drafts are being extracted when they are still in the active directory
a new config variable needed for this functionality was added in this commit: https://github.com/YangCatalog/deployment/commit/909b5a508a667e7a18eebe2bb2e5fa75b6a04d35

resolves #266 